### PR TITLE
Make it possible to set the Zend API version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["php", "php-extension"]
 description = "A library to build PHP extensions in Rust."
 license = "MIT"
 repository = "https://github.com/rethinkphp/php-rs"
+edition = "2018"
 
 [dependencies]
 libc = "0.2.0"

--- a/examples/helloworld/Cargo.toml
+++ b/examples/helloworld/Cargo.toml
@@ -2,6 +2,7 @@
 name = "helloworld"
 version = "0.1.0"
 authors = ["Jin Hu <bixuehujin@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 libc = "0.2.0"

--- a/examples/helloworld/src/lib.rs
+++ b/examples/helloworld/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(unused_variables)]
-#![feature(link_args)]
 
 extern crate libc;
 extern crate php;
@@ -9,7 +8,6 @@ use php::*;
 use zend::*;
 use php::info::*;
 
-#[link_args = "-Wl,-undefined,dynamic_lookup"]
 extern {
     pub fn php_printf(format: *const c_char , ...) -> size_t;
 }
@@ -44,6 +42,8 @@ pub extern fn get_module() -> *mut zend::Module {
     let mut entry = Box::new(zend::Module::new(
         c_str!("demo"),
         c_str!("0.1.0-dev"),
+        20180731,
+        c_str!("API20180731,NTS")
     ));
 
     entry.set_info_func(php_module_info);

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,7 +1,6 @@
 use libc::*;
 use std::ffi::CString;
 
-#[link_args = "-Wl,-undefined,dynamic_lookup"]
 extern {
     pub fn php_info_print_table_start();
     pub fn php_info_print_table_row(num_cols: c_int, ...) -> c_void;

--- a/src/zend/module.rs
+++ b/src/zend/module.rs
@@ -112,10 +112,10 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn new(name: *const c_char, version: *const c_char) -> Module {
+    pub fn new(name: *const c_char, version: *const c_char, zend_api: c_uint, build_id: *const c_char) -> Module {
         Module {
             size: mem::size_of::<Module>() as u16,
-            zend_api: 20151012,
+            zend_api: zend_api,
             zend_debug: 0,
             zts: 0,
             ini_entry: std::ptr::null(),
@@ -137,7 +137,7 @@ impl Module {
             type_: 0,
             handle: std::ptr::null(),
             module_number: 0,
-            build_id: c_str!("API20151012,NTS"),
+            build_id: build_id,
         }
     }
 


### PR DESCRIPTION
I know that this is a breaking change. But it doesn't make sense to let the build_id version as constant. I also took the opportunity to migrate this to the last rust edition. 